### PR TITLE
Escape "pipe" symbols in Markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ func main() {
 |Operator|Description|
 |--------|-----------|
 |`&&`|logical and|
-|`||`|logical or|
+|`\|\|`|logical or|
 |`!`|logical not|
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ func main() {
 |`/`|quotient|
 |`%`|remainder|
 |`&`|bitwise and|
-|`|`|bitwise or|
+|`\|`|bitwise or|
 |`^`|bitwise xor|
 |`&^`|bit clear (and not)|
 |`<<`|left shift|


### PR DESCRIPTION
Otherwise they disappear!

https://stackoverflow.com/questions/23723396/how-to-show-the-pipe-symbol-in-markdown-table